### PR TITLE
share id amongst devices

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "stop": "pm2 stop pm2.config.js",
     "logs": "pm2 logs",
     "dev": "parcel src/public/index.pug && parcel watch src/public/index.pug",
-    "build": "tsc && parcel build src/public/index.pug"
+    "build": "tsc && parcel build src/public/*.pug"
   },
   "author": "",
   "license": "ISC",

--- a/readme.md
+++ b/readme.md
@@ -12,3 +12,4 @@ Please refer to the `readme.md` in the `setup` directory.
 5. Visit `localhost:9000` in your browser.
 ##### References
 1. [https://jmcker.github.io/Peer-to-Peer-Cue-System/](https://jmcker.github.io/Peer-to-Peer-Cue-System/)
+2. [https://medium.com/samsung-internet-dev/building-an-internet-connected-phone-with-peerjs-775bd6ffebec](https://medium.com/samsung-internet-dev/building-an-internet-connected-phone-with-peerjs-775bd6ffebec)

--- a/src/public/index.pug
+++ b/src/public/index.pug
@@ -7,6 +7,8 @@ html
   body
     p#selfID.
     br
+    a(href="link" target="_blank") Link another device
+    br
     input(type="text" name="ConnectPeer" placeholder="connect to ID" id="peerID" required)
     button#connectButton(type="button") Connect
     input(type="text" name="messageBox" placeholder="message" id="message" required)

--- a/src/public/javascripts/index.ts
+++ b/src/public/javascripts/index.ts
@@ -9,15 +9,15 @@ if(!storage.peer_messages) storage.setItem("peer_messages", `{"0":"0"}`);
 const peerMessages = JSON.parse(storage.peer_messages);
 
 const oldMessages = (peerID) => {
-  connection.innerHTML = `Connected to ${peerID}.`
-  messages.innerHTML = "";
+  document.getElementById("connection").innerHTML = `Connected to ${peerID}.`
+  document.getElementById("messages").innerHTML = "";
   if(!peerMessages[peerID]) {
     peerMessages[peerID] = [];
     storage.peer_messages = JSON.stringify(peerMessages);
   }
   if(peerMessages[peerID].length !== 0)
     peerMessages[peerID].forEach( (a) => {
-      messages.innerHTML = `<br> ${a[0]}: ${a[1]} ${a[2]} ${messages.innerHTML}`;
+      document.getElementById("messages").innerHTML = `<br> ${a[0]}: ${a[1]} ${a[2]} ${document.getElementById("messages").innerHTML}`;
     });
 }
 
@@ -60,7 +60,7 @@ const sendPeerID = () => {
     conn.on("data", (message) => getMessage(message));
   });
   conn.on("close", () => {
-    connection.innerHTML = "Connection closed by peer.";
+    document.getElementById("connection").innerHTML = "Connection closed by peer.";
   });
 }
 document.getElementById("connectButton").addEventListener("click", sendPeerID);
@@ -69,7 +69,7 @@ const sendMessage = () => {
   const message = document.getElementById("message").value;
   conn.send(message);
   const date = new Date();
-  messages.innerHTML = `<br> Self: ${date} ${message} ${messages.innerHTML}`;
+  document.getElementById("messages").innerHTML = `<br> Self: ${date} ${message} ${document.getElementById("messages").innerHTML}`;
   const peerID = conn.peer;
   const peerMessages = JSON.parse(storage.peer_messages); 
   peerMessages[peerID].push(["Self", date, message]);
@@ -86,13 +86,13 @@ const getPeerID = () => {
     oldMessages(peerID);
   });
   conn.on("close", () => {
-    connection.innerHTML = "Connection closed by peer.";
+    document.getElementById("connection").innerHTML = "Connection closed by peer.";
   });
 }
 const getMessage = (message) => {
   const peerID = conn.peer;
   const date = new Date();
-  messages.innerHTML = `<br> Peer: ${date} ${message} ${messages.innerHTML}`;
+  document.getElementById("messages").innerHTML = `<br> Peer: ${date} ${message} ${document.getElementById("messages").innerHTML}`;
   const peerMessages = JSON.parse(storage.peer_messages);
   peerMessages[peerID].push(["Peer", date, message]);
   storage.peer_messages = JSON.stringify(peerMessages);
@@ -111,9 +111,9 @@ peer.on("connection", (connection) => {
 });
 
 peer.on("disconnected", () => {
-  connection.innerHTML = "Connection lost.";
+  document.getElementById("connection").innerHTML = "Connection lost.";
 });
 peer.on("close", () => {
   conn = null;
-  connection.innerHTML = "Connection lost.";
+  document.getElementById("connection").innerHTML = "Connection lost.";
 });

--- a/src/public/javascripts/index.ts
+++ b/src/public/javascripts/index.ts
@@ -99,14 +99,13 @@ const getMessage = (message) => {
 }
 peer.on("connection", (connection) => {
   const conf = confirm(`Incoming connection from ${connection.peer}`);
-  conn = connection;
   if(conf) {
+    conn = connection;
     getPeerID();
-    connection.on("data", getMessage);
+    conn.on("data", getMessage);
   }
   else {
-    conn.close();
-    conn = null;
+    connection.close();
   }
 });
 

--- a/src/public/javascripts/link.ts
+++ b/src/public/javascripts/link.ts
@@ -1,0 +1,39 @@
+import axios from "axios";
+const data = axios({
+    method: "post",
+    url: "/config",
+    responseType: "json",
+  })
+  .then(res => {return res.data;})
+  .catch(e => {console.log(e.message);});
+
+const storage = window.localStorage;
+
+const ID = storage.peer;
+const peer = new Peer(ID, await data);
+console.log(peer);
+peer.on("open", (id) => {
+  console.log("h, ",id);
+  document.getElementById("selfID").innerHTML = `Your ID is ${id}.`;
+});
+
+let conn = null;
+const sendSelfID = () => {
+  const selfID = document.getElementById("allowConnectionsFrom").value;
+  conn = peer.connect(selfID);
+}
+document.getElementById("allowConnectionsFromButton").addEventListener("click", sendSelfID);
+
+peer.on("connection", (connection) => {
+  const conf = confirm(`Change ID to ${connection.peer}`);
+  conn = connection;
+  if(conf) {
+    storage.setItem(":peer", connection.peer);
+    conn.close();
+    conn = null;
+  }
+  else {
+    conn.close();
+    conn = null;
+  }
+});

--- a/src/public/javascripts/link.ts
+++ b/src/public/javascripts/link.ts
@@ -10,30 +10,29 @@ const data = axios({
 const storage = window.localStorage;
 
 const ID = storage.peer;
-const peer = new Peer(ID, await data);
-console.log(peer);
+const peer = new Peer(`link-${ID}`, await data);
 peer.on("open", (id) => {
-  console.log("h, ",id);
-  document.getElementById("selfID").innerHTML = `Your ID is ${id}.`;
+  document.getElementById("selfID").innerHTML = `Your ID is ${id.slice(5)}.`;
 });
 
 let conn = null;
 const sendSelfID = () => {
   const selfID = document.getElementById("allowConnectionsFrom").value;
-  conn = peer.connect(selfID);
+  conn = peer.connect(`link-${selfID}`);
 }
 document.getElementById("allowConnectionsFromButton").addEventListener("click", sendSelfID);
 
 peer.on("connection", (connection) => {
-  const conf = confirm(`Change ID to ${connection.peer}`);
-  conn = connection;
+  const newID = connection.peer.slice(5);
+  const conf = confirm(`Change ID to ${newID}`);
   if(conf) {
-    storage.setItem(":peer", connection.peer);
+    conn = connection;
+    storage.setItem("peer", newID);
+    document.getElementById("selfID").innerHTML = `Your ID is now ${newID}. Please close this window.`;
     conn.close();
     conn = null;
   }
   else {
-    conn.close();
-    conn = null;
+    connection.close();
   }
 });

--- a/src/public/link.pug
+++ b/src/public/link.pug
@@ -1,0 +1,15 @@
+doctype html
+html
+  head
+    title Local road: links
+    link(rel="stylesheet", href="./stylesheets/stylesheet.css")
+    link(href="data:image/x-icon;base64,A" rel="icon" type="image/x-icon")
+  body
+    p#selfID.
+    input(type="text" name="AllowConnectionsFrom" placeholder="Allow Connections From" id="allowConnectionsFrom" required)
+    button#allowConnectionsFromButton(type="button") Allow
+    br
+    p
+      a(href="/") back
+  script(src="javascripts/peerjs.min.js")
+  script(type="module", src="javascripts/link.ts")

--- a/src/server.ts
+++ b/src/server.ts
@@ -26,6 +26,7 @@ const clientConfig = {
 app.use(express.static("dist"));
 
 app.get("/", (req: Request, res: Response) => res.sendFile("/index.html", { root: "./dist" }));
+app.get("/link", (req: Request, res: Response) => res.sendFile("/link.html", { root: "./dist" }));
 
 app.post("/config", (req: Request, res: Response) => res.send(clientConfig));
 


### PR DESCRIPTION
Given two devices `A` and `B` with id `IDA` and `IDB`, respectively, suppose you wish to change the id of device B to `IDA`. 
1. Travel to `/link` on both devices. (click `Link another device` from the front page).
2. Copy `IDB` to the `Allow Connections From` field at the `/link` URL on device `A`. 
3. Click `allow` on device `A`.
4. Click `OK` on device `B`.

Device `B` now has id `IDA`.